### PR TITLE
chore: 🤖 set up mongo replicaset for local env

### DIFF
--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -4,6 +4,22 @@ services:
     image: mongo:6-jammy
     ports:
       - "27017:27017"
+    entrypoint:
+      - bash
+      - -c
+      - |
+        openssl rand -base64 756 > /data/replica.key
+        chmod 400 /data/replica.key
+        chown 999:999 /data/replica.key
+        exec docker-entrypoint.sh $$@
+    command: "mongod --bind_ip_all --replSet rs0 --keyFile /data/replica.key --port 27017 --quiet --logpath /dev/null"
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'localhost:27017'}]}) }" | mongosh -u ${MONGO_USER} -p ${MONGO_PASSWORD} --port 27017
+      interval: 5s
+      timeout: 30s
+      start_period: 0s
+      start_interval: 1s
+      retries: 30
     volumes:
       - ./mongo/init-scripts:/docker-entrypoint-initdb.d
     environment:

--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ module.exports = {
 	},
 	mongo: {
 		uri: process.env.NODE_ENV === 'local'
-			? `mongodb://${process.env.MONGO_USER}:${process.env.MONGO_PASSWORD}@127.0.0.1:27017/${process.env.MONGO_DB}`
+			? `mongodb://${process.env.MONGO_USER}:${process.env.MONGO_PASSWORD}@127.0.0.1:27017/${process.env.MONGO_DB}?replicaSet=rs0`
 			: process.env.MONGO_URI,
 	},
 	mailer: mailer.createTransport({


### PR DESCRIPTION
Modified `docker-compose.yaml` to instantiate a mongodb instance with replicaset architecture. Replicaset initialization is automized by the healthcheck and the entrypoint automatically generates a replicaset key and gives the container read permissions
